### PR TITLE
Elevate to sudo and retain permissions during long running scripts

### DIFF
--- a/sudohost.sh
+++ b/sudohost.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Ask for the administrator password upfront
+sudo -v
+
+# Keep-alive: update existing `sudo` time stamp until `.macos` has finished
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+
 #--sudo)
 #  SUDO_ENABLE=true;
 #;;


### PR DESCRIPTION
I've added two blocks of code. The first elevates to `sudo` and requests that the user enters their password. The second block ensures that even long-running scripts retain the ability to issue `sudo` after.

I'm not sure that if you include additional scripts or source additional scripts that the `sudo` will be maintained as these will be sub-shells.